### PR TITLE
Integrated a Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+## Avoid documentation temporary artifacts to be commited to the main repository
+.docs_venv
+doc
+
 
 # Created by https://www.gitignore.io/api/vim,data,linux,emacs,python,ansible,erlang,vagrant
 

--- a/.travis/deploy_docs.sh
+++ b/.travis/deploy_docs.sh
@@ -9,7 +9,7 @@ SOURCE_BRANCH="master"
 TARGET_BRANCH="gh-pages"
 
 function doCompile {
-  mkdocs build -d out
+  make doc
 }
 
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
@@ -24,21 +24,21 @@ REPO=`git config remote.origin.url`
 SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
 SHA=`git rev-parse --verify HEAD`
 
-# Clone the existing gh-pages for this repo into out/
+# Clone the existing gh-pages for this repo into doc/
 # Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deply)
-git clone $REPO out
-cd out
+git clone $REPO doc
+cd doc
 git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
 cd ..
 
 # Clean out existing contents
-rm -rf out/**/* || exit 0
+rm -rf doc/**/* || exit 0
 
 # Run our compile script
 doCompile
 
 # Now let's go have some fun with the cloned repo
-cd out
+cd doc
 git config user.name "Travis CI"
 git config user.email "$COMMIT_AUTHOR_EMAIL"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,45 @@
+# Contributing
+## Test modifications
+
 We use `vagrant` to test the Allspark single node environment.
-You can see the [install nodes here](https://www.vagrantup.com/docs/installation/).
+You can see the [install notes here](https://www.vagrantup.com/docs/installation/).
 The box used is the `centos/7` one.
-You can test modification using this vm like so :
+You can test modification using Vagrant like so :
 ```sh
 
 # Run this once, vagrant will let you know if it needs updates
 vagrant box add centos/7
 
 # Create a virtual machine, run the install.yml playbook on it
-# It currently needs to be online when running this command.
-vagrant up
+# It needs to be online when running this command.
+make test
 
 # Stop & destroy the VM
-vagrant destroy -f
+make clean
+```
 
+## Documentation
+
+### Build
+You can build the documetation using the `make doc` command. The resulting artifacts will be stored in the `doc` directory.
+To view the resulting docs, you can use any http server, like :
+```sh
+# Python3
+python3 -m http.server
+
+# Python2
+python2 -m SimpleHTTPServer
+```
+
+### Hot reload
+If you want to review your work while editing, you can use :
+```sh
+# Generate the virtualenv
+make doc
+
+# Switch the python runtime to the venv one
+source .docs_venv/bin/activate
+
+# Serve the documentation on http://localhost:8000
+mkdocs serve
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+
+PIP_GLOBAL_ARGS =
+PIP_COMMAND_ARGS =
+RM = rm -f
+DOCS_SRCS := $(shell find docs/pages -name '*.md')
+
+doc: $(DOCS_SRCS) docs/requirements.txt
+	@echo "Setting up docs virtual environment"
+	@EXIT_CODE=0
+	@[ -d .docs_venv ] || virtualenv .docs_venv
+	@source .docs_venv/bin/activate && \
+	( \
+		pip $(PIP_GLOBAL_ARGS) install $(PIP_COMMAND_ARGS) -r docs/requirements.txt && \
+		echo "Building docs" && \
+		mkdocs build -d doc || \
+		EXIT_CODE=1 \
+	); deactivate
+	@exit $(EXIT_CODE)
+
+
+clean:
+	@echo "Removing documentation artifacts"
+	@$(RM) -r doc .docs_venv
+	@echo "Removing Ansible retry files"
+	@find . -name '*.retry' | xargs $(RM)
+	@echo "Tearing down development Vagrant box."
+	@(which vagrant >/dev/null && vagrant destroy -f) || echo "Vagrant not installed, skipping VM destruction."
+
+test:
+	vagrant up
+
+.PHONY: clean install test

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ doc: $(DOCS_SRCS) docs/requirements.txt
 	@echo "Setting up docs virtual environment"
 	@EXIT_CODE=0
 	@[ -d .docs_venv ] || virtualenv .docs_venv
-	@source .docs_venv/bin/activate && \
+	@. .docs_venv/bin/activate && \
 	( \
 		pip $(PIP_GLOBAL_ARGS) install $(PIP_COMMAND_ARGS) -r docs/requirements.txt && \
 		echo "Building docs" && \


### PR DESCRIPTION
Integrated a Makefile with the following modifications : 
- Docs are now build in a virtualenv, this will prevent some package version issues while working on the documentation on a dev environment.
- Cleaning automation (vagrant box + venv + ansible retry files)
- Improved contributing section to use the makefile commands where relevant.


I did not included any ansible related tasks in the Makefile, so the release, setup and install procedures are still launched "manually". 