### PR TITLE
Hotfix/docs make not executed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - '3.6'
-install: pip install -r docs/requirements.txt
 jobs:
   include:
   - stage: deploy

--- a/.travis/deploy_docs.sh
+++ b/.travis/deploy_docs.sh
@@ -9,15 +9,17 @@ SOURCE_BRANCH="master"
 TARGET_BRANCH="gh-pages"
 
 function doCompile {
-  make doc
+  make doc && \
+  mv doc/* out/ && \
+  rm -rf doc
 }
 
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
-if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
-    echo "Skipping deploy; just doing a build."
-    doCompile
-    exit 0
-fi
+# if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
+#     echo "Skipping deploy; just doing a build."
+#     doCompile
+#     exit 0
+# fi
 
 # Save some useful information
 REPO=`git config remote.origin.url`
@@ -26,19 +28,19 @@ SHA=`git rev-parse --verify HEAD`
 
 # Clone the existing gh-pages for this repo into doc/
 # Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deply)
-git clone $REPO doc
+git clone $REPO out
 cd doc
 git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
 cd ..
 
 # Clean out existing contents
-rm -rf doc/**/* || exit 0
+rm -rf out/**/* || exit 0
 
 # Run our compile script
 doCompile
 
 # Now let's go have some fun with the cloned repo
-cd doc
+cd out
 git config user.name "Travis CI"
 git config user.email "$COMMIT_AUTHOR_EMAIL"
 

--- a/.travis/deploy_docs.sh
+++ b/.travis/deploy_docs.sh
@@ -17,6 +17,7 @@ function doCompile {
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
 if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
     echo "Skipping deploy; just doing a build."
+    mkdir out
     doCompile
     exit 0
 fi

--- a/.travis/deploy_docs.sh
+++ b/.travis/deploy_docs.sh
@@ -29,7 +29,7 @@ SHA=`git rev-parse --verify HEAD`
 # Clone the existing gh-pages for this repo into doc/
 # Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deply)
 git clone $REPO out
-cd doc
+cd out
 git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
 cd ..
 

--- a/.travis/deploy_docs.sh
+++ b/.travis/deploy_docs.sh
@@ -15,11 +15,11 @@ function doCompile {
 }
 
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
-# if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
-#     echo "Skipping deploy; just doing a build."
-#     doCompile
-#     exit 0
-# fi
+if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
+    echo "Skipping deploy; just doing a build."
+    doCompile
+    exit 0
+fi
 
 # Save some useful information
 REPO=`git config remote.origin.url`


### PR DESCRIPTION
This hotfix fixes `make` ignoring docs generation because the name of the rule `doc` was the same as the directory created by `.travis/deploy_docs.sh`. I changed the destination directory from `doc` to `out` in order to trigger a build in the CI.

Moreover, i triggered a deployment from the branch by commenting the branch check in the script and restoring it after the website validation.

Lastly, i disabled the `install` Travis step, because it is now handled in the `Makefile`

[Last stable build from this branch](https://travis-ci.org/TheFkinCompany/allspark/builds/402977767)
