### PR TITLE
Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Report us a bug
+
+---
+
+### Describe the bug
+
+A clear and concise description of what the bug is.
+
+### To Reproduce
+
+> **note**: You might want to use the Vagrant environment to create a reproducible scenario triggering the bug.
+
+Steps to reproduce the behavior:
+1. '...'
+2. '....'
+
+### Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+### Allspark informations
+
+- **Allspark**
+  - *configuration*
+  ```yaml
+  # allspark group_vars/* configurations
+  ```
+- **Control machine**
+  - *Operating system* : '...
+  - *Ansible version* :
+  ```
+  output of `ansible --version`
+  ```
+  - *Vagrant version* (if used to reproduce the issue) : '...'
+- **Allspark server**
+  - *Operating system* :
+  - *Docker version* :
+
+### Additional context
+
+Add any other context about the problem here. (e.g: logs)

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea
+
+---
+
+### Story
+- as a '...' is want '...'
+- as a '...' is want '...'
+
+---
+### Motivation
+Why is this feature needed ?
+
+---
+### Acceptance criteria
+
+---
+### Implementation proposal
+
+---
+### Status
+
+- [ ] Implementation
+- [ ] Test coverage
+- [ ] Documentation
+- [ ] '...'

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Current behaviour
+
+### Expected behaviour
+
+### Changes proposed
+
+-  [ ] '...'
+-  [ ] '...'
+-  [ ] '...'
+
+### Related issues
+
+- #
+
+> **note** : Put closes #XXXX in your commit message to auto-close the issue that your PR fixes (if such).


### PR DESCRIPTION
### Current behaviour

When creating an issue or a pull request on the allspark repository, the
user has to start redacting from scratch, which cause :
- Issues
  - Unclear way to reproduce bugs
  - Missing informations
  - Lack of clarity for feature requests
- Pull requests
  - Feature not correcly explained
  - Unclear changes and PR objectives

### Expected behaviour

The users should be guided by templates when trying to create :

- Bug report
- Feature request
- Pull request

on the Github repository.

### Changes proposed

-  [x] Bug report template
  - Description
  - Reproductability
  - Expected behaviour
  - Allspark / system informations
-  [x] Feature request template (Story)
  - Description
  - Motivation
  - Implementation
  - Acceptance
  - Status
-  [x] Pull request
  - Behaviour
  - Changes proposed
  - Related issues
