### PR TITLE
Feature/download role

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,15 @@
 # Contributing
+
+## Development
+
+### Docker images
+
+The docker images are downloaded in the `download` role.
+If you need to add an image to allspark, add the corresponding entry
+in the `roles/download/defaults/main.yml` file. You can then refer to
+your image using `{{ downloads.your_image.image }}:{{ downloads.your_image.tag }}`.
+
+
 ## Test modifications
 
 We use `vagrant` to test the Allspark single node environment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,28 @@
 The docker images are downloaded in the `download` role.
 If you need to add an image to allspark, add the corresponding entry
 in the `roles/download/defaults/main.yml` file. You can then refer to
-your image using `{{ downloads.your_image.image }}:{{ downloads.your_image.tag }}`.
+your image using `{{ downloads.component_name.image }}:{{ downloads.component_name.tag }}`.
+
+By convention, the image `name` and `tag` are exposed in separated variables `${component_name}_image` and `${component_name}_tag`.
+
+_e.g_:
+```yaml
+# Images
+gitlab_image: gitlab/gitlab-ce
+
+# Tags
+gitlab_tag: latest
+
+# Downloads
+downloads:
+  gitlab:
+    enabled: "{{ allspark_gitlab.enabled }}"
+    image: "{{ gitlab_image }}"
+    tag: "{{ gitlab_tag }}"
+```
+
+This format is helful to centralize `downloads` for an easier access in roles, the exposed variables also allow the user to
+easily override an image/tag with a `ansible-playbook -e "${component_name}_image=my-image"`
 
 
 ## Test modifications

--- a/docs/pages/install.md
+++ b/docs/pages/install.md
@@ -16,6 +16,24 @@ your needs, like:
     (each component will be exposed as a subdomain).
   - Enable or disable component using their `enabled` boolean toggle
 
+
+!!! note
+    You can customize the image or tag for a component by overriding the `component_image` and `component_tag`, using either :
+
+    - [Ansible extra vars](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#passing-variables-on-the-command-line)
+    - Add those variables to your `group_vars/all.yml` file.
+
+    _e.g_: (group_vars)
+    ```yaml
+    # Change gitlab-ce to gitlab-ee
+    gitlab_image: gitlab_ee
+    gitlab_tag: latest
+    ```
+    You can access the complete list of available components in the [roles/downloads/defaults/main.yml](https://github.com/TheFkinCompany/allspark/blob/master/roles/download/defaults/main.yml) file.
+
+!!! warning
+    For offline install, the images configuration must be the same on both end.
+
 ### Online install
 
 - Change the hosts file to point to the allspark machine.

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -10,14 +10,12 @@ allspark_docker_version: "17.03.2"
 allspark_ldap:
   enabled: false
   organization: Allspark
-  image: osixia/openldap:1.2.0
-  management_image: osixia/phpldapadmin:0.7.1
 
 allspark_monitoring:
   enabled: true
 
 allspark_traefik:
-  selfsigned: 
+  selfsigned:
     enabled: false
     # For example country: FR
     country: XX
@@ -26,44 +24,22 @@ allspark_traefik:
     organisation: myteam
     organizational_unit: myorganizational_unit
     common_name: "*.{{ allspark_root_domain }}"
-  image: traefik:latest
-
-allspark_portainer:
-  image: portainer/portainer:latest
 
 allspark_rocketchat:
   enabled: true
-  image: rocket.chat:latest
-  database_image: mongo:latest
-
-allspark_prometheus:
-  image: prom/prometheus:v2.1.0
-
-allspark_grafana:
-  image: grafana/grafana:latest
-
-allspark_node_exporter:
-  image: prom/node-exporter
-
-allspark_cadvisor:
-  image: google/cadvisor:latest
 
 allspark_gitlab:
   enabled: false
   with_runner: false
-  image: gitlab/gitlab-ce:latest
-  runner_image: gitlab/gitlab-runner:latest
   lfs_enabled: true
 
 allspark_jenkins:
   enabled: false
-  image: jenkins/jenkins
   # Toggle default plugin import from release.
   import_plugins: true
 
 allspark_sonarqube:
   enabled: false
-  image: sonarqube:latest
 
 ### Release configuration
 # Should not be here

--- a/install.yml
+++ b/install.yml
@@ -1,26 +1,10 @@
-- name: Run using a project directory
+- name: Allspark installer
   hosts: all
-  tasks:
-  - name: Setup system dependencies
-    include_role:
-      name: system
-
-  - name: Setup software infrastructure
-    include_role:
-      name: infra
-
-  - name: Setup Monitoring
-    include_role:
-      name: monitoring
-
-  - name: Setup Gitlab
-    include_role:
-      name: gitlab
-
-  - name: Setup Jenkins
-    include_role:
-      name: jenkins
-
-  - name: Setup Sonarqube
-    include_role:
-      name: sonarqube
+  roles:
+    - system
+    - { role: download, tags: [ "download", "prepare" ] }
+    - infra
+    - monitoring
+    - gitlab
+    - jenkins
+    - sonarqube

--- a/release.yml
+++ b/release.yml
@@ -1,24 +1,7 @@
 - name: Package an Allspark release
   hosts: all
-  vars:
-    docker_images:
-    - jenkins/jenkins
-    - centos:7
-    - blacklabelops/volumerize
-    - "{{ allspark_traefik.image }}"
-    - "{{ allspark_portainer.image }}"
-    - "{{ allspark_sonarqube.image }}"
-    - "{{ allspark_rocketchat.image }}"
-    - "{{ allspark_rocketchat.database_image }}"
-    - "{{ allspark_prometheus.image }}"
-    - "{{ allspark_grafana.image }}"
-    - "{{ allspark_node_exporter.image }}"
-    - "{{ allspark_cadvisor.image }}"
-    - "{{ allspark_gitlab.image }}"
-    - "{{ allspark_gitlab.runner_image }}"
-    - "{{ allspark_ldap.image }}"
-    - "{{ allspark_ldap.management_image }}"
-
+  roles:
+  - { role: download, force_download: true }
   tasks:
   - name: Creating release directory
     file:
@@ -39,19 +22,19 @@
       REQUIREMENTS_FILE: "{{ playbook_dir }}/files/jenkins_plugins.txt"
     when: allspark_jenkins.enabled
 
-  - name: Exporting Docker images
+  - name: Export Docker images
     docker_image:
       state: present
       archive_path: "{{ allspark_release_tmp_directory}}/images/{{ item | b64encode }}.tar"
-      name: "{{ item }}"
-    with_items: "{{ docker_images }}"
-
+      name: "{{ downloads[item].image }}:{{ downloads[item].tag }}"
+    with_items: "{{ downloads.keys() | list }}"
 
   # - name: Compress release into destination file
   #   archive:
   #     path: "{{ allspark_release_tmp_directory }}/*"
   #     dest: "{{ allspark_release_destination }}"
   #     remove: True
+  #   become: true
 
   # Using shell instead of unarchive because pigz (multicore compression)
   # is not yet supported by the archive module
@@ -59,6 +42,7 @@
     shell: "tar -c --use-compress-program=pigz -f {{ allspark_release_destination }} -C {{ allspark_release_tmp_directory }} ."
     args:
       warn: False
+    become: true
 
   - name: Clean up release directory
     file:

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1,0 +1,65 @@
+# Downloads
+downloads:
+  gitlab:
+    enabled: "{{ allspark_gitlab.enabled }}"
+    image: "gitlab/gitlab-ce"
+    tag: "latest"
+  rocketchat:
+    enabled: "{{ allspark_rocketchat.enabled }}"
+    image: "rocket.chat"
+    tag: "latest"
+  rocketchat_mongodb:
+    enabled: "{{ allspark_rocketchat.enabled }}"
+    image: "mongo"
+    tag: "latest"
+  traefik:
+    enabled: true
+    image: "traefik"
+    tag: "latest"
+  grafana:
+    enabled: "{{ allspark_monitoring.enabled }}"
+    image: "grafana/grafana"
+    tag: "latest"
+  prometheus:
+    enabled: "{{ allspark_monitoring.enabled }}"
+    image: "prom/prometheus"
+    tag: "v2.1.0"
+  cadvisor:
+    enabled: "{{ allspark_monitoring.enabled }}"
+    image: "google/cadvisor"
+    tag: "latest"
+  node_exporter:
+    enabled: "{{ allspark_monitoring.enabled }}"
+    image: "prom/node-exporter"
+    tag: "latest"
+  sonarqube:
+    enabled: "{{ allspark_sonarqube.enabled }}"
+    image: "sonarqube"
+    tag: "latest"
+  portainer:
+    enabled: true
+    image: "portainer/portainer"
+    tag: "latest"
+  openldap:
+    enabled: "{{ allspark_ldap.enabled }}"
+    image: "osixia/openldap"
+    tag: "1.2.0"
+  phpldapadmin:
+    enabled: "{{ allspark_ldap.enabled }}"
+    image: "osixia/phpldapadmin"
+    tag: "0.7.1"
+  gitlab_runner:
+    enabled: "{{ allspark_gitlab.with_runner }}"
+    image: "gitlab/gitlab-runner"
+    tag: "latest"
+  jenkins:
+    enabled: "{{ allspark_jenkins.enabled }}"
+    image: "jenkins/jenkins"
+    tag: "latest"
+
+
+# Misc
+
+## Set this to true to force the download of every images, even if they are
+## disabled in the configuration
+force_download: false

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1,70 +1,105 @@
+# Images
+gitlab_image: gitlab/gitlab-ce
+rocketchat_image: rocket.chat
+rocketchat_mongodb_image: mongo
+traefik_image: traefik
+grafana_image: grafana/grafana
+prometheus_image: prom/prometheus
+cadvisor_image: google/cadvisor
+node_exporter_image: prom/node-exporter
+sonarqube_image: sonarqube
+portainer_image: portainer/portainer
+openldap_image: osixia/openldap
+phpldapadmin_image: osixia/phpldapadmin
+gitlab_runner_image: gitlab/gitlab-runner
+jenkins_image: jenkins/jenkins
+centos_image: centos
+volumerize_image: blacklabelops/volumerize
+
+# Tags
+gitlab_tag: latest
+rocketchat_tag: latest
+rocketchat_mongodb_tag: latest
+traefik_tag: latest
+grafana_tag: latest
+prometheus_tag: v2.1.0
+cadvisor_tag: latest
+node_exporter_tag: latest
+sonarqube_tag: latest
+portainer_tag: latest
+openldap_tag: 1.2.0
+phpldapadmin_tag: 0.7.1
+gitlab_runner_tag: latest
+jenkins_tag: latest
+centos_tag: 7
+volumerize_tag: latest
+
 # Downloads
 downloads:
-  gitlab:
-    enabled: "{{ allspark_gitlab.enabled }}"
-    image: "gitlab/gitlab-ce"
-    tag: "latest"
-  rocketchat:
-    enabled: "{{ allspark_rocketchat.enabled }}"
-    image: "rocket.chat"
-    tag: "latest"
-  rocketchat_mongodb:
-    enabled: "{{ allspark_rocketchat.enabled }}"
-    image: "mongo"
-    tag: "latest"
-  traefik:
-    enabled: true
-    image: "traefik"
-    tag: "latest"
-  grafana:
-    enabled: "{{ allspark_monitoring.enabled }}"
-    image: "grafana/grafana"
-    tag: "latest"
-  prometheus:
-    enabled: "{{ allspark_monitoring.enabled }}"
-    image: "prom/prometheus"
-    tag: "v2.1.0"
   cadvisor:
     enabled: "{{ allspark_monitoring.enabled }}"
-    image: "google/cadvisor"
-    tag: "latest"
-  node_exporter:
-    enabled: "{{ allspark_monitoring.enabled }}"
-    image: "prom/node-exporter"
-    tag: "latest"
-  sonarqube:
-    enabled: "{{ allspark_sonarqube.enabled }}"
-    image: "sonarqube"
-    tag: "latest"
-  portainer:
-    enabled: true
-    image: "portainer/portainer"
-    tag: "latest"
-  openldap:
-    enabled: "{{ allspark_ldap.enabled }}"
-    image: "osixia/openldap"
-    tag: "1.2.0"
-  phpldapadmin:
-    enabled: "{{ allspark_ldap.enabled }}"
-    image: "osixia/phpldapadmin"
-    tag: "0.7.1"
-  gitlab_runner:
-    enabled: "{{ allspark_gitlab.with_runner }}"
-    image: "gitlab/gitlab-runner"
-    tag: "latest"
-  jenkins:
-    enabled: "{{ allspark_jenkins.enabled }}"
-    image: "jenkins/jenkins"
-    tag: "latest"
+    image: "{{ cadvisor_image }}"
+    tag: "{{ cadvisor_tag }}"
   centos:
     enabled: true
-    image: "centos"
-    tag: "7"
+    image: "{{ centos_image }}"
+    tag: "{{ centos_tag }}"
+  gitlab:
+    enabled: "{{ allspark_gitlab.enabled }}"
+    image: "{{ gitlab_image }}"
+    tag: "{{ gitlab_tag }}"
+  gitlab_runner:
+    enabled: "{{ allspark_gitlab.with_runner }}"
+    image: "{{ gitlab_runner_image }}"
+    tag: "{{ gitlab_runner_tag }}"
+  grafana:
+    enabled: "{{ allspark_monitoring.enabled }}"
+    image: "{{ grafana_image }}"
+    tag: "{{ grafana_tag }}"
+  jenkins:
+    enabled: "{{ allspark_jenkins.enabled }}"
+    image: "{{ jenkins_image }}"
+    tag: "{{ jenkins_tag }}"
+  node_exporter:
+    enabled: "{{ allspark_monitoring.enabled }}"
+    image: "{{ node_exporter_image }}"
+    tag: "{{ node_exporter_tag }}"
+  openldap:
+    enabled: "{{ allspark_ldap.enabled }}"
+    image: "{{ openldap_image }}"
+    tag: "{{ openldap_tag }}"
+  phpldapadmin:
+    enabled: "{{ allspark_ldap.enabled }}"
+    image: "{{ phpldapadmin_image }}"
+    tag: "{{ phpldapadmin_tag }}"
+  portainer:
+    enabled: true
+    image: "{{ portainer_image }}"
+    tag: "{{ portainer_tag }}"
+  prometheus:
+    enabled: "{{ allspark_monitoring.enabled }}"
+    image: "{{ prometheus_image }}"
+    tag: "{{ prometheus_tag }}"
+  rocketchat:
+    enabled: "{{ allspark_rocketchat.enabled }}"
+    image: "{{ rocketchat_image }}"
+    tag: "{{ rocketchat_tag }}"
+  rocketchat_mongodb:
+    enabled: "{{ allspark_rocketchat.enabled }}"
+    image: "{{ rocketchat_mongodb_image }}"
+    tag: "{{ rocketchat_mongodb_tag }}"
+  sonarqube:
+    enabled: "{{ allspark_sonarqube.enabled }}"
+    image: "{{ sonarqube_image }}"
+    tag: "{{ sonarqube_tag }}"
+  traefik:
+    enabled: true
+    image: "{{ traefik_image }}"
+    tag: "{{ traefik_tag }}"
   volumerize:
     enabled: true
-    image: "blacklabelops/volumerize"
-    tag: "latest"
-
+    image: "{{ volumerize_image }}"
+    tag: "{{ volumerize_tag }}"
 
 # Misc
 

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -56,6 +56,14 @@ downloads:
     enabled: "{{ allspark_jenkins.enabled }}"
     image: "jenkins/jenkins"
     tag: "latest"
+  centos:
+    enabled: true
+    image: "centos"
+    tag: "7"
+  volumerize:
+    enabled: true
+    image: "blacklabelops/volumerize"
+    tag: "latest"
 
 
 # Misc

--- a/roles/download/tasks/download_image.yml
+++ b/roles/download/tasks/download_image.yml
@@ -1,0 +1,5 @@
+- name: "[Download] {{ item }}"
+  docker_image:
+    state: present
+    name: "{{ downloads[item].image }}:{{ downloads[item].tag }}"
+  when: downloads[item].enabled or force_download

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -1,0 +1,2 @@
+- include_tasks: download_image.yml
+  with_items: "{{ downloads.keys() | list }}"

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -25,7 +25,7 @@
   docker_container:
     name: gitlab
     state: "{{ allspark_gitlab.enabled and 'started' or 'absent'}}"
-    image: "{{ allspark_gitlab.image }}"
+    image: "{{ downloads.gitlab.image }}:{{ downloads.gitlab.tag }}"
     hostname: "gitlab.{{ allspark_root_domain }}"
     volumes:
       - "allspark_gitlab_data:/var/opt/gitlab"

--- a/roles/jenkins/tasks/main.yml
+++ b/roles/jenkins/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Starting Jenkins master
   docker_container:
     name: jenkins
-    image: "{{ allspark_jenkins.image }}"
+    image: "{{ downloads.jenkins.image }}:{{ downloads.jenkins.tag }}"
     state: "{{ allspark_jenkins.enabled and 'started' or 'absent'}}"
     networks:
       - name: allspark

--- a/roles/ldap/tasks/main.yml
+++ b/roles/ldap/tasks/main.yml
@@ -17,7 +17,7 @@
   docker_container:
     name: ldap_backend
     hostname: ldap_backend
-    image: "{{ allspark_ldap.image }}"
+    image: "{{ downloads.openldap.image }}:{{ downloads.openldap.tag }}"
     state: "{{ allspark_ldap.enabled and 'started' or 'absent'}}"
     networks:
       - name: allspark
@@ -33,7 +33,7 @@
 - name: Starting LDAP web management dashboard
   docker_container:
     name: ldap_management
-    image: "{{ allspark_ldap.management_image }}"
+    image: "{{ downloads.phpldapadmin.image }}:{{ downloads.phpldapadmin.tag }}"
     state: "{{ allspark_ldap.enabled and 'started' or 'absent'}}"
     networks:
       - name: allspark

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Setup CAdvisor for containers monitoring
   docker_container:
     name: cadvisor
-    image: "{{ allspark_cadvisor.image }}"
+    image: "{{ downloads.cadvisor.image }}:{{ downloads.cadvisor.tag }}"
     state: "{{ allspark_monitoring.enabled and 'started' or 'absent' }}"
     volumes: >-
       [
@@ -20,7 +20,7 @@
 - name: Setup node exporter
   docker_container:
     name: node-exporter
-    image: "{{ allspark_node_exporter.image }}"
+    image: "{{ downloads.node_exporter.image }}:{{ downloads.node_exporter.tag }}"
     state: "{{ allspark_monitoring.enabled and 'started' or 'absent' }}"
     volumes:
       - /proc:/host/proc:ro
@@ -55,7 +55,7 @@
 - name: Setup Prometheus metrics collector
   docker_container:
     name: prometheus
-    image: "{{ allspark_prometheus.image }}"
+    image: "{{ downloads.prometheus.image }}:{{ downloads.prometheus.tag }}"
     state: "{{ allspark_monitoring.enabled and 'started' or 'absent' }}"
     volumes:
       - "{{ allspark_root_directory }}/config/prometheus/:/etc/prometheus/"
@@ -88,7 +88,7 @@
 - name: Setup Grafana for vizualization
   docker_container:
     name: grafana
-    image: "{{ allspark_grafana.image }}"
+    image: "{{ downloads.grafana.image }}:{{ downloads.grafana.tag }}"
     state: "{{ allspark_monitoring.enabled and 'started' or 'absent' }}"
     volumes:
       - allspark_grafana_data:/var/lib/grafana

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -48,7 +48,7 @@
 - name: Setup ingress manager
   docker_container:
     name: traefik
-    image: "{{ allspark_traefik.image }}"
+    image: "{{ downloads.traefik.image }}:{{ downloads.traefik.tag }}"
     volumes: >-
       [
       "{{ allspark_root_directory }}/config/traefik/traefik.toml:/etc/traefik/traefik.toml",

--- a/roles/sonarqube/tasks/main.yml
+++ b/roles/sonarqube/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: Starting Sonarqube master
   docker_container:
     name: sonarqube
-    image: "{{ allspark_sonarqube.image }}"
+    image: "{{ downloads.sonarqube.image }}:{{ downloads.sonarqube.tag }}"
     state: "{{ allspark_sonarqube.enabled and 'started' or 'absent'}}"
     networks:
       - name: allspark

--- a/roles/utils/tasks/main.yml
+++ b/roles/utils/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Setup Portainer as infra service
   docker_container:
     name: portainer
-    image: "{{ allspark_portainer.image }}"
+    image: "{{ downloads.portainer.image }}:{{ downloads.portainer.tag }}"
     volumes:
       - "allspark_portainer_data:/data"
       - "/var/run/docker.sock:/var/run/docker.sock"
@@ -29,7 +29,7 @@
 - name: Setup MongoDB chat service database
   docker_container:
     name: rocketchat_database
-    image: "{{ allspark_rocketchat.database_image }}"
+    image: "{{ downloads.rocketchat_mongodb.image }}:{{ downloads.rocketchat_mongodb.tag }}"
     state: "{{ allspark_rocketchat.enabled and 'started' or 'absent'}}"
     networks:
       - name: allspark
@@ -40,7 +40,7 @@
 - name: Setup RocketChat service
   docker_container:
     name: rocketchat
-    image: "{{ allspark_rocketchat.image }}"
+    image: "{{ downloads.rocketchat.image }}:{{ downloads.rocketchat.tag }}"
     state: "{{ allspark_rocketchat.enabled and 'started' or 'absent'}}"
     env:
       MONGO_URL: mongodb://rocketchat_database/rocketchat

--- a/setup.yml
+++ b/setup.yml
@@ -1,30 +1,8 @@
 # Load offline release
 - name: Load dependencies for an Allspark release
   hosts: all
-  vars:
-    docker_images:
-    - centos:7
-    - jenkins/jenkins
-    - blacklabelops/volumerize
-    - "{{ allspark_traefik.image }}"
-    - "{{ allspark_portainer.image }}"
-    - "{{ allspark_sonarqube.image }}"
-    - "{{ allspark_rocketchat.image }}"
-    - "{{ allspark_rocketchat.database_image }}"
-    - "{{ allspark_prometheus.image }}"
-    - "{{ allspark_grafana.image }}"
-    - "{{ allspark_node_exporter.image }}"
-    - "{{ allspark_cadvisor.image }}"
-    - "{{ allspark_gitlab.image }}"
-    - "{{ allspark_gitlab.runner_image }}"
-    - "{{ allspark_ldap.image }}"
-    - "{{ allspark_ldap.management_image }}"
 
   tasks:
-  - name: Loading default variables
-    include_vars:
-      dir: defaults
-
   - name: Creating release directory
     file:
       state: directory
@@ -35,12 +13,18 @@
       src: "{{ allspark_release_destination }}"
       dest: "{{ allspark_release_tmp_directory }}"
 
+  - name: Downloading Docker images
+    include_role:
+      name: download
+    vars:
+      force_download: true
+
   - name: Importing Docker images
     docker_image:
       state: present
-      load_path: "{{ allspark_release_tmp_directory}}/images/{{ item | b64encode }}.tar"
-      name: "{{ item }}"
-    with_items: "{{ docker_images }}"
+      load_path: "{{ allspark_release_tmp_directory }}/images/{{ item | b64encode }}.tar"
+      name: "{{ downloads[item].image }}:{{ downloads[item].tag }}"
+    with_items: "{{ downloads.keys() | list }}"
 
   - name: Creating Jenkins plugins volume
     docker_volume:
@@ -50,7 +34,7 @@
   - name: Importing Jenkins volume
     docker_container:
       name: volume_importer
-      image: blacklabelops/volumerize
+      image: "{{ downloads.volumerize.image }}:{{ downloads.volumerize.tag }}"
       volumes:
         - allspark_jenkins_plugins:/source
         - "{{ allspark_release_tmp_directory }}/dependencies/jenkins_plugins:/backup"

--- a/setup.yml
+++ b/setup.yml
@@ -1,7 +1,8 @@
 # Load offline release
 - name: Load dependencies for an Allspark release
   hosts: all
-
+  roles:
+  - { role: download, force_download: true }
   tasks:
   - name: Creating release directory
     file:
@@ -12,12 +13,6 @@
     unarchive:
       src: "{{ allspark_release_destination }}"
       dest: "{{ allspark_release_tmp_directory }}"
-
-  - name: Downloading Docker images
-    include_role:
-      name: download
-    vars:
-      force_download: true
 
   - name: Importing Docker images
     docker_image:


### PR DESCRIPTION
### Current behaviour
- The components behaviour and images/tag are configured together in the `group_vars/all.yml`
- Downloads are made on a role basis, with the `docker_container` ansible module.
- docker images must be kept in sync in the `release.yml` and `setup.yml` to export/import images on system for `docker_container`.
- image variables embed tags

### Expected behaviour
- Image and tag should be in separated variables
- Downloads should be centralised in a role
  - it make it easier to split the imports/relase mechanisms
  - it avoids duplication of the images/tag in the `setup.yml`, `release.yml` and `group_vars/all.yml`
- Images and tag should remain easily overriden by the user

### Changes proposed

- [x] centralise docker image download in the `download` role.
- [x] centralise images/versions in the `role/download/defaults/main.yml` file.
- [x] remove image configuration in `group_vars/main.yml`, `setup.yml` and `release.yml`
- [x] Improved documentation on image / tag customisation
- [x] `CONTRIBUTING.md` documentation on image download convention.

### Related issues

- #19 
> It will be easier to fix the images tag with this PR, and will allow to automate the image tag updates with a bot ( like [PyUp](https://pyup.io/) for pip packages)

- #18
> The documentation gives the example of changing gitlab-ce to gitlab-ee, it will make it more intuitive to configure when first diving through the install doc until we decide if gitlab-ee should be the open-source default

- #21 
> We must take care of this branch when merging, the last one to merge will need to rebase from master to apply download conventions on the changes proposed in the `backup` branch.
