### PR TITLE
Feature/makefile rule docs dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,12 +66,6 @@ python2 -m SimpleHTTPServer
 ### Hot reload
 If you want to review your work while editing, you can use :
 ```sh
-# Generate the virtualenv
-make doc
-
-# Switch the python runtime to the venv one
-source .docs_venv/bin/activate
-
 # Serve the documentation on http://localhost:8000
-mkdocs serve
+make doc-dev
 ```


### PR DESCRIPTION
### Current behaviour

You have to manually 
- build the doc 
- activate the virtualenv
- `mkdocs serve`

### Expected behaviour

A makefile rule abstract these steps

### Changes proposed

-  [x] Added `make doc-dev` rule for hot reload
-  [x] Edited CONTRIBUTING.md to document this feature
