### PR TITLE
Disable --no-auth option and activate --admin-password-file

### DIFF
--- a/roles/local_datas/tasks/main.yml
+++ b/roles/local_datas/tasks/main.yml
@@ -20,5 +20,5 @@
   register: admin_password_file
 
 - name: Generate random admin password
-  shell: "echo $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c26) > {{ allspark_root_directory}}/data/secrets/admin_password.txt"
+  shell: "echo -n $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c26) > {{ allspark_root_directory}}/data/secrets/admin_password.txt"
   when: not admin_password_file.stat.exists

--- a/roles/utils/tasks/main.yml
+++ b/roles/utils/tasks/main.yml
@@ -8,8 +8,9 @@
     image: "{{ downloads.portainer.image }}:{{ downloads.portainer.tag }}"
     volumes:
       - "allspark_portainer_data:/data"
+      - "{{ allspark_root_directory }}/data/secrets/admin_password.txt:/data/secrets/portainer-pass"
       - "/var/run/docker.sock:/var/run/docker.sock"
-    command: "--admin-password-file {{ allspark_root_directory }}/data/secrets/admin_password.txt --no-analytics --host unix:///var/run/docker.sock"
+    command: "--admin-password-file /data/secrets/portainer-pass --no-analytics --host unix:///var/run/docker.sock"
     networks:
       - name: allspark
     labels:

--- a/roles/utils/tasks/main.yml
+++ b/roles/utils/tasks/main.yml
@@ -9,7 +9,7 @@
     volumes:
       - "allspark_portainer_data:/data"
       - "/var/run/docker.sock:/var/run/docker.sock"
-    command: --no-auth --no-analytics --host unix:///var/run/docker.sock
+    command: "--admin-password-file {{ allspark_root_directory }}/data/secrets/admin_password.txt --no-analytics --host unix:///var/run/docker.sock"
     networks:
       - name: allspark
     labels:


### PR DESCRIPTION
### Current behaviour
Actually the product to administrate the container start without security authentication
### Expected behaviour
We need to add password as a security reason
### Changes proposed

-  [ ] Add passsword file as argument to portainer container to activate secure authentication

### Related issues

- #24 

> **note** : Put closes #24 in your commit message to auto-close the issue that your PR fixes (if such).
