### PR TITLE
Hotfix/pip module

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -2,6 +2,7 @@
   hosts: all
   roles:
     - system
+    - pip
     - { role: download, tags: [ "download", "prepare" ] }
     - infra
     - monitoring

--- a/roles/pip/files/requirements.txt
+++ b/roles/pip/files/requirements.txt
@@ -1,0 +1,2 @@
+docker-py>=1.7.0
+pyopenssl>=0.15

--- a/roles/pip/tasks/main.yml
+++ b/roles/pip/tasks/main.yml
@@ -6,3 +6,4 @@
 - name: Installing python libraries using requirements file in Ansible
   pip:
     requirements: "{{ allspark_root_directory }}/config/pip-requirements.txt"
+  become: true

--- a/roles/pip/tasks/main.yml
+++ b/roles/pip/tasks/main.yml
@@ -12,7 +12,7 @@
     src: files/requirements.txt
     dest: "{{ allspark_root_directory }}/config/pip-requirements.txt" 
 
-- name: Installing python libraries using requirements file in Ansible
+- name: Installing python libraries using requirements file
   pip:
     requirements: "{{ allspark_root_directory }}/config/pip-requirements.txt"
-  become: true
+    extra_args: --user

--- a/roles/pip/tasks/main.yml
+++ b/roles/pip/tasks/main.yml
@@ -1,4 +1,13 @@
-- send [Pip] Requirements to remote server
+- name: allspark data directory creation
+  file:
+    state: directory
+    path: "{{ allspark_root_directory }}/{{item}}"
+  with_items:
+    - config
+    - data
+    - data/secrets
+
+- name: send [Pip] Requirements to remote server
   copy:
     src: files/requirements.txt
     dest: "{{ allspark_root_directory }}/config/pip-requirements.txt" 

--- a/roles/pip/tasks/main.yml
+++ b/roles/pip/tasks/main.yml
@@ -1,0 +1,8 @@
+- send [Pip] Requirements to remote server
+  copy:
+    src: files/requirements.txt
+    dest: "{{ allspark_root_directory }}/config/pip-requirements.txt" 
+
+- name: Installing python libraries using requirements file in Ansible
+  pip:
+    requirements: "{{ allspark_root_directory }}/config/pip-requirements.txt"

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -17,15 +17,3 @@
     path: "{{ allspark_root_directory }}"
     owner: "{{ ansible_user }}"
   become: true
-
-- name: Pip - docker-py
-  pip:
-    name: docker-py
-  become: true
-
-- name: Pip - pyopenssl
-  pip:
-    name: pyopenssl
-    version: 0.15
-  become: true
-


### PR DESCRIPTION
### Current behaviour

Actually we have a fixed pyopenssl, after i make the PR #54 to upadte to the last version
---
### Expected behaviour

I want to have the docker-py and pyopenssl with at least a require version by ansible

---
### Modifications

> What are the changes involved to match with the expected behaviour ?

-  [x] Refactor Pip install module
-  [x] Add requirement files
-  [x] specify a minimum version

---
### Related issues

> What issue are affected by or affecting this pull request.

- resolve #53 

### Status

- [ ] Implementation