### PR TITLE
Hotfix/pip install via yum

### DIFF
--- a/roles/system/tasks/rhel7.yml
+++ b/roles/system/tasks/rhel7.yml
@@ -63,6 +63,12 @@
   become: true
   when: pip_install.rc != 0
 
+- name: Install [Docker]
+  yum:
+    name: pip
+  become: true
+  when: pip_install.rc != 0
+
 - name: test docker install
   shell: which docker
   changed_when: false

--- a/roles/system/tasks/rhel7.yml
+++ b/roles/system/tasks/rhel7.yml
@@ -58,14 +58,9 @@
   changed_when: false
   register: pip_install
 
-- name: Install pip
-  shell: "curl https://bootstrap.pypa.io/get-pip.py | python -"
-  become: true
-  when: pip_install.rc != 0
-
-- name: Install [Docker]
+- name: Install [Python-pip]
   yum:
-    name: pip
+    name: python-pip
   become: true
   when: pip_install.rc != 0
 


### PR DESCRIPTION
### Current behaviour

Actually the python-pip is install via the curl command for REHL instead of yum module.

---
### Expected behaviour

Use the yum module to install yum package on REHL/CentOS system

---
### Modifications

-  [x] Only replace the curl by the yum module

---
### Status

- [ ] Implementation
- [ ] Test coverage
- [ ] Documentation
- [ ] ...
