### PR TITLE
Hotfix/mattermost indepotence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,6 @@ clean:
 	@(which vagrant >/dev/null && vagrant destroy -f) || echo "Vagrant not installed, skipping VM destruction."
 
 test:
-	vagrant up
+	vagrant up --provision
 
 .PHONY: clean install test doc-dev

--- a/roles/utils/tasks/main.yml
+++ b/roles/utils/tasks/main.yml
@@ -67,9 +67,10 @@
   shell: "echo -n $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c26) > {{ allspark_root_directory}}/data/secrets/admin_password_mattermostdb.txt"
   when: not admin_password_mattermost_file.stat.exists
 
-- name: Register random admin password
+- name: Register mattermost admin password
   shell: "cat {{ allspark_root_directory}}/data/secrets/admin_password_mattermostdb.txt"
   register: allspark_admin_password_mattermostdb
+  changed_when: false
 
 - name: Test [AtRestEncryptKey] existence
   stat: path="{{ allspark_root_directory}}/data/secrets/AtRestEncryptKey.txt"
@@ -82,6 +83,7 @@
 - name: Register random [AtRestEncryptKey]
   shell: "cat {{ allspark_root_directory}}/data/secrets/AtRestEncryptKey.txt"
   register: allspark_AtRestEncryptKey
+  changed_when: false
 
 - name: Test [PublicLinkSalt] existence
   stat: path="{{ allspark_root_directory}}/data/secrets/PublicLinkSalt.txt"
@@ -94,6 +96,7 @@
 - name: Register random [PublicLinkSalt]
   shell: "cat {{ allspark_root_directory}}/data/secrets/PublicLinkSalt.txt"
   register: allspark_PublicLinkSalt
+  changed_when: false
 
 - name: Test [InviteSalt] existence
   stat: path="{{ allspark_root_directory}}/data/secrets/InviteSalt.txt"
@@ -106,6 +109,7 @@
 - name: Register random [InviteSalt]
   shell: "cat {{ allspark_root_directory}}/data/secrets/InviteSalt.txt"
   register: allspark_InviteSalt
+  changed_when: false
 
 - name: MatterMost config directory
   file:
@@ -115,11 +119,23 @@
 - name: Generate Mattermost config
   template:
     src: templates/config.json.j2
+    dest: "{{ allspark_root_directory }}/config/mattermost/config_i.json"
+  register: mattermost_template
+  when: allspark_mattermost.enabled
+
+## Mattermost change the contents of it's configuration file at runtime
+## To avoid indepotency break using only the template module on this file,
+## we first copy it to config_i.json and then override runtime config
+## only if this task changed.
+- name: Copy Mattermost runtime configuration
+  copy:
+    remote_src: yes
+    src: "{{ allspark_root_directory }}/config/mattermost/config_i.json"
     dest: "{{ allspark_root_directory }}/config/mattermost/config.json"
     owner: 2000
     group: 2000
   become: true
-  when: allspark_mattermost.enabled
+  when: mattermost_template is changed
 
 - name: Docker volumes creation
   docker_volume:
@@ -169,4 +185,3 @@
       "traefik.frontend.rule": "Host:mattermost.{{ allspark_root_domain }}"
       "traefik.enable": "true"
     restart_policy: always
-

--- a/roles/utils/templates/config.json.j2
+++ b/roles/utils/templates/config.json.j2
@@ -108,7 +108,7 @@
     },
     "SqlSettings": {
         "DriverName": "postgres",
-        "DataSource": "postgres://postgres:{{ allspark_admin_password_mattermostdb }}@mattermost_database:5432/mattermostdb?sslmode=disable\u0026connect_timeout=10",
+        "DataSource": "postgres://postgres:{{ allspark_admin_password_mattermostdb.stdout }}@mattermost_database:5432/mattermostdb?sslmode=disable&connect_timeout=10",
         "DataSourceReplicas": [],
         "DataSourceSearchReplicas": [],
         "MaxIdleConns": 20,


### PR DESCRIPTION
### Current behaviour

> Describe here the observed behaviour of the software.

Mattermost is not indepotent, as descibed in #67 


---
### Expected behaviour

> Describe here what you expected the software to do instead.

No changed tasks on second `vagrant up --provision`

---
### Modifications

> What are the changes involved to match with the expected behaviour ?

-  [x] Changed `make test` to add `--provision` to vagrant up
-  [x] Corrected password issue with mattermost db connection in config.
-  [x] Added `changed_when: false` to secret reading tasks
- [x] Avoided configuration templating each time (because mattermost edit it's config at runtime) by adding a copy of the original templated file next to the runtime config. The configuration override is then triggered by a change in this copy.

---
### Related issues

> What issue are affected by or affecting this pull request.

- resolve #67 

---
### Status

- [x] Implementation